### PR TITLE
ENG-4637: add sec_code to CreateLinkedPaymentRequest

### DIFF
--- a/e2e_tests/payment_test.py
+++ b/e2e_tests/payment_test.py
@@ -73,3 +73,40 @@ def test_update_book_payment():
     request = PatchBookPaymentRequest(payment_id, tags)
     response = client.payments.update(request)
     assert response.data.type == "bookPayment"
+
+def test_create_linked_payment_request_includes_sec_code_when_set():
+    relationships = {
+        "account": Relationship("depositAccount", "111111"),
+        "counterparty": Relationship("counterparty", "222222"),
+    }
+    request = CreateLinkedPaymentRequest(
+        100,
+        "ACH payment",
+        relationships,
+        None,
+        None,
+        None,
+        None,
+        sec_code="WEB",
+    )
+    payload = request.to_json_api()
+    assert payload["data"]["attributes"]["secCode"] == "WEB"
+
+
+def test_create_linked_payment_request_omits_sec_code_when_unset():
+    relationships = {
+        "account": Relationship("depositAccount", "111111"),
+        "counterparty": Relationship("counterparty", "222222"),
+    }
+    request = CreateLinkedPaymentRequest(
+        100,
+        "ACH payment",
+        relationships,
+        None,
+        None,
+        None,
+        None,
+    )
+    payload = request.to_json_api()
+    assert "secCode" not in payload["data"]["attributes"]
+

--- a/unit/models/payment.py
+++ b/unit/models/payment.py
@@ -237,16 +237,21 @@ class CreateInlinePaymentRequest(CreatePaymentBaseRequest):
 class CreateLinkedPaymentRequest(CreatePaymentBaseRequest):
     def __init__(self, amount: int, description: str, relationships: Dict[str, Relationship], addenda: Optional[str],
                  verify_counterparty_balance: Optional[bool], idempotency_key: Optional[str],
-                 tags: Optional[Dict[str, str]], direction: str = "Credit", same_day: Optional[bool] = False):
+                 tags: Optional[Dict[str, str]], direction: str = "Credit", same_day: Optional[bool] = False,
+                 sec_code: Optional[str] = None):
         CreatePaymentBaseRequest.__init__(self, amount, description, relationships, idempotency_key, tags, direction, same_day=same_day)
         self.addenda = addenda
         self.verify_counterparty_balance = verify_counterparty_balance
+        self.sec_code = sec_code
 
     def to_json_api(self) -> Dict:
         payload = CreatePaymentBaseRequest.to_json_api(self)
 
         if self.addenda:
             payload["data"]["attributes"]["addenda"] = self.addenda
+
+        if self.sec_code:
+            payload["data"]["attributes"]["secCode"] = self.sec_code
 
         if self.verify_counterparty_balance:
             payload["data"]["attributes"]["verifyCounterpartyBalance"] = self.verify_counterparty_balance


### PR DESCRIPTION
## Summary
Adds an optional `sec_code` to `CreateLinkedPaymentRequest`, emitted as `secCode` in `to_json_api()` only when set (mirrors the existing `addenda` handling). Lets Truss send NACHA SEC code `CCD` on business debit ACH originations.

## Why
Unit defaults business debits to `WEB`, which permits the 60-day R10 consumer "unauthorized" return window. `CCD` enforces the 2-banking-day corporate window. Implements spike ENG-4466.

## Test plan
- Added no-network unit tests in `e2e_tests/payment_test.py` asserting `secCode` is present when `sec_code="CCD"` and omitted when unset.

## Consumed by
- Truss-pmts/api#4674 — pins this commit and injects `sec_code=CCD` on business debit-checkout debits.
- Truss-pmts/web-app#1106 — collects the payer counterparty type.