### PR TITLE
feat: add sandbox dispute simulation methods

### DIFF
--- a/unit/api/dispute_resource.py
+++ b/unit/api/dispute_resource.py
@@ -16,3 +16,31 @@ class DisputeResource(BaseResource):
             return UnitResponse[DisputeDTO](DtoDecoder.decode(data), None)
         else:
             return UnitError.from_json_api(response.json())
+
+    def sandbox_create_dispute(self, request: SimulateDisputeRequest) -> Union[UnitResponse[DisputeDTO], UnitError]:
+        payload = request.to_json_api()
+        response = super().post(f"sandbox/{self.resource}", payload)
+        return self.__handle_dispute_response(response)
+
+    def sandbox_credit_provisionally(self, dispute_id: str) -> Union[UnitResponse[DisputeDTO], UnitError]:
+        response = super().post(f"sandbox/{self.resource}/{dispute_id}/credit-provisionally")
+        return self.__handle_dispute_response(response)
+
+    def sandbox_resolve_won(self, dispute_id: str) -> Union[UnitResponse[DisputeDTO], UnitError]:
+        response = super().post(f"sandbox/{self.resource}/{dispute_id}/resolve-won")
+        return self.__handle_dispute_response(response)
+
+    def sandbox_resolve_lost(self, dispute_id: str) -> Union[UnitResponse[DisputeDTO], UnitError]:
+        response = super().post(f"sandbox/{self.resource}/{dispute_id}/resolve-lost")
+        return self.__handle_dispute_response(response)
+
+    def sandbox_deny(self, dispute_id: str) -> Union[UnitResponse[DisputeDTO], UnitError]:
+        response = super().post(f"sandbox/{self.resource}/{dispute_id}/deny")
+        return self.__handle_dispute_response(response)
+
+    def __handle_dispute_response(self, response) -> Union[UnitResponse[DisputeDTO], UnitError]:
+        if super().is_20x(response.status_code):
+            data = response.json().get("data")
+            return UnitResponse[DisputeDTO](DtoDecoder.decode(data), None)
+        else:
+            return UnitError.from_json_api(response.json())

--- a/unit/models/dispute.py
+++ b/unit/models/dispute.py
@@ -1,3 +1,5 @@
+import json
+
 from unit.utils import date_utils
 from unit.models import *
 
@@ -52,3 +54,40 @@ class DisputeDTO(object):
             attributes.get("decisionReason"),
             relationships,
         )
+
+
+class SimulateDisputeRequest(UnitRequest):
+    def __init__(self, account_id: str, transaction_id: str, amount: Optional[int] = None):
+        self.account_id = account_id
+        self.transaction_id = transaction_id
+        self.amount = amount
+
+    def to_json_api(self) -> Dict:
+        payload = {
+            "data": {
+                "type": "dispute",
+                "attributes": {},
+                "relationships": {
+                    "account": {
+                        "data": {
+                            "type": "account",
+                            "id": self.account_id
+                        }
+                    },
+                    "transaction": {
+                        "data": {
+                            "type": "transaction",
+                            "id": self.transaction_id
+                        }
+                    }
+                }
+            }
+        }
+
+        if self.amount is not None:
+            payload["data"]["attributes"]["amount"] = self.amount
+
+        return payload
+
+    def __repr__(self):
+        return json.dumps(self.to_json_api())


### PR DESCRIPTION
## Summary
Adds Unit sandbox dispute simulation support so callers can drive a card dispute through its full lifecycle (mirrors the existing `authorization_requests.sandbox_simulate` pattern).

- `SimulateDisputeRequest` model (`unit/models/dispute.py`) — builds the JSON:API create-dispute payload with `account` + `transaction` relationships and an optional `amount`.
- Five `DisputeResource` sandbox methods (`unit/api/dispute_resource.py`):
  - `sandbox_create_dispute` → `POST /sandbox/disputes`
  - `sandbox_credit_provisionally` → `POST /sandbox/disputes/{id}/credit-provisionally`
  - `sandbox_resolve_won` → `POST /sandbox/disputes/{id}/resolve-won`
  - `sandbox_resolve_lost` → `POST /sandbox/disputes/{id}/resolve-lost`
  - `sandbox_deny` → `POST /sandbox/disputes/{id}/deny`

Endpoints per Unit docs: https://www.unit.co/docs/api/disputes/simulations/

## Consumer
Used by the Truss `api` repo's `simulate_dispute` management command / `sb_dispute_simulation` helpers to exercise dispute, provisional-credit, won/lost/denied flows against a forwarded (sandbox) environment.

## Test plan
- [ ] Run against Unit sandbox: create a dispute for a posted purchaseTransaction, then credit-provisionally and resolve-won/lost/deny, and confirm the corresponding `dispute.created` / `dispute.statusChanged` / `disputeTransaction` webhooks fire.

Made with [Cursor](https://cursor.com)