### PR TITLE
Add AuthorizationAmountChangedEvent

### DIFF
--- a/unit/models/codecs.py
+++ b/unit/models/codecs.py
@@ -248,6 +248,9 @@ mappings = {
         "authorization.canceled": lambda _id, _type, attributes, relationships:
         AuthorizationCanceledEvent.from_json_api(_id, _type, attributes, relationships),
 
+        "authorization.amountChanged": lambda _id, _type, attributes, relationships:
+        AuthorizationAmountChangedEvent.from_json_api(_id, _type, attributes, relationships),
+
         "authorization.declined": lambda _id, _type, attributes, relationships:
         AuthorizationDeclinedEvent.from_json_api(_id, _type, attributes, relationships),
 

--- a/unit/models/event.py
+++ b/unit/models/event.py
@@ -91,6 +91,20 @@ class AuthorizationCanceledEvent(BaseEvent):
                                           attributes["recurring"], attributes.get("tags"),
                                           relationships)
 
+class AuthorizationAmountChangedEvent(BaseEvent):
+    def __init__(self, id: str, created_at: datetime, old_amount: int, new_amount: int,
+                 tags: Optional[Dict[str, str]], relationships: Optional[Dict[str, Relationship]]):
+        BaseEvent.__init__(self, id, created_at, tags, relationships)
+        self.type = 'authorization.amountChanged'
+        self.attributes["oldAmount"] = old_amount
+        self.attributes["newAmount"] = new_amount
+
+    @staticmethod
+    def from_json_api(_id, _type, attributes, relationships):
+        return AuthorizationAmountChangedEvent(_id, date_utils.to_datetime(attributes["createdAt"]),
+                                               attributes["oldAmount"], attributes["newAmount"],
+                                               attributes.get("tags"), relationships)
+
 class AuthorizationDeclinedEvent(BaseEvent):
     def __init__(self, id: str, created_at: datetime, amount: int, card_last_4_digits: str, merchant: Merchant,
                  reason: str, recurring: str, tags: Optional[Dict[str, str]] = None,


### PR DESCRIPTION
## Summary
- Add `AuthorizationAmountChangedEvent` to model Unit's `authorization.amountChanged` webhook, exposing `oldAmount` and `newAmount` (mirrors the existing `AuthorizationCanceledEvent`).
- Register `authorization.amountChanged` in the codec `mappings` so incoming events deserialize to the new event type.

## Context
Consumed by Truss api PR Truss-pmts/api#4781 to keep an unposted purchase's amount — and the derived card credit hold — in sync when Unit revises an authorization amount.

Made with [Cursor](https://cursor.com)