### PR TITLE
Add sandbox authorization increase/cancel simulation methods

### DIFF
--- a/unit/api/authorization_resource.py
+++ b/unit/api/authorization_resource.py
@@ -26,3 +26,19 @@ class AuthorizationResource(BaseResource):
             return UnitResponse[AuthorizationDTO](DtoDecoder.decode(data), None)
         else:
             return UnitError.from_json_api(response.json())
+
+    def sandbox_increase(self, request: SimulateAuthorizationIncrease) -> Union[UnitResponse[AuthorizationDTO], UnitError]:
+        response = super().post(f"sandbox/{self.resource}/{request.authorization_id}/increase", request.to_json_api())
+        if super().is_20x(response.status_code):
+            data = response.json().get("data")
+            return UnitResponse[AuthorizationDTO](DtoDecoder.decode(data), None)
+        else:
+            return UnitError.from_json_api(response.json())
+
+    def sandbox_cancel(self, request: SimulateAuthorizationCancel) -> Union[UnitResponse[AuthorizationDTO], UnitError]:
+        response = super().post(f"sandbox/{self.resource}/{request.authorization_id}/cancel", request.to_json_api())
+        if super().is_20x(response.status_code):
+            data = response.json().get("data")
+            return UnitResponse[AuthorizationDTO](DtoDecoder.decode(data), None)
+        else:
+            return UnitError.from_json_api(response.json())

--- a/unit/models/authorization.py
+++ b/unit/models/authorization.py
@@ -121,3 +121,41 @@ class ListAuthorizationParams(UnitParams):
         if self.sort:
             parameters["sort"] = self.sort
         return parameters
+
+
+class SimulateAuthorizationIncrease(UnitRequest):
+    def __init__(self, authorization_id: str, amount: int, card_last_4_digits: str, account_id: str):
+        self.authorization_id = authorization_id
+        self.amount = amount
+        self.card_last_4_digits = card_last_4_digits
+        self.account_id = account_id
+
+    def to_json_api(self) -> Dict:
+        return {
+            "data": {
+                "type": "authorization",
+                "attributes": {
+                    "amount": self.amount,
+                    "cardLast4Digits": self.card_last_4_digits,
+                },
+                "relationships": {
+                    "account": {"data": {"type": "depositAccount", "id": self.account_id}}
+                },
+            }
+        }
+
+
+class SimulateAuthorizationCancel(UnitRequest):
+    def __init__(self, authorization_id: str, account_id: str):
+        self.authorization_id = authorization_id
+        self.account_id = account_id
+
+    def to_json_api(self) -> Dict:
+        return {
+            "data": {
+                "type": "authorization",
+                "relationships": {
+                    "account": {"data": {"type": "depositAccount", "id": self.account_id}}
+                },
+            }
+        }


### PR DESCRIPTION
## Summary
- Add `AuthorizationResource.sandbox_increase` and `AuthorizationResource.sandbox_cancel` (`POST sandbox/authorizations/{id}/increase` and `.../cancel`).
- Add the `SimulateAuthorizationIncrease` and `SimulateAuthorizationCancel` request models.

These let the Truss card-purchase E2E harness simulate `authorization.amountChanged` and `authorization.canceled` against the Unit sandbox. Previously this logic was vendored inside the api repo; this moves it into the SDK fork so the dependency is pinned and reproducible.

## Test plan
- [ ] Pin this commit in the api repo `src/requirements.txt` and run the card E2E harness `auth_increase_*` / `auth_canceled_*` scenarios against forwarded develop.

Made with [Cursor](https://cursor.com)