### PR TITLE
feat: add AccountResource.verify for Unit accounts/verify API

### DIFF
--- a/e2e_tests/test_account_verify.py
+++ b/e2e_tests/test_account_verify.py
@@ -1,0 +1,88 @@
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from unit.api.account_resource import AccountResource
+from unit.models.account import AccountVerifyRequest
+
+
+class TestAccountVerify(unittest.TestCase):
+    def test_account_verify_request_to_json_api(self):
+        request = AccountVerifyRequest(
+            routing_number="051000017", account_number="10000123"
+        )
+        self.assertEqual(
+            request.to_json_api(),
+            {
+                "data": {
+                    "type": "accountVerify",
+                    "attributes": {
+                        "routingNumber": "051000017",
+                        "accountNumber": "10000123",
+                    },
+                }
+            },
+        )
+
+    @patch("unit.api.base_resource.requests.post")
+    def test_account_verify_match(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "data": {
+                "exists": True,
+                "account": {
+                    "type": "depositAccount",
+                    "id": "1000000",
+                    "attributes": {
+                        "createdAt": "2023-01-01T00:00:00.000Z",
+                        "name": "Peter Parker",
+                        "status": "Open",
+                        "depositProduct": "checking",
+                        "routingNumber": "051000017",
+                        "accountNumber": "10000123",
+                        "currency": "USD",
+                        "balance": 10000,
+                        "hold": 0,
+                        "available": 10000,
+                        "tags": {},
+                    },
+                    "relationships": {
+                        "customer": {
+                            "data": {"type": "individualCustomer", "id": "100"}
+                        }
+                    },
+                },
+            }
+        }
+        mock_post.return_value = mock_response
+
+        resource = AccountResource("https://api.s.unit.sh", "token")
+        request = AccountVerifyRequest(
+            routing_number="051000017", account_number="10000123"
+        )
+        response = resource.verify(request=request)
+
+        self.assertTrue(response.data.exists)
+        self.assertEqual(response.data.account.id, "1000000")
+        self.assertEqual(response.data.account.relationships["customer"].id, "100")
+
+    @patch("unit.api.base_resource.requests.post")
+    def test_account_verify_no_match(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": {"exists": False}}
+        mock_post.return_value = mock_response
+
+        resource = AccountResource("https://api.s.unit.sh", "token")
+        request = AccountVerifyRequest(
+            routing_number="051000017", account_number="10000123"
+        )
+        response = resource.verify(request=request)
+
+        self.assertFalse(response.data.exists)
+        self.assertIsNone(response.data.account)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit/api/account_resource.py
+++ b/unit/api/account_resource.py
@@ -86,3 +86,17 @@ class AccountResource(BaseResource):
         else:
             return UnitError.from_json_api(response.json())
 
+    def verify(self, request: AccountVerifyRequest,
+               timeout: float = None) -> Union[UnitResponse[AccountVerifyDTO], UnitError]:
+        payload = request.to_json_api()
+        response = super().post(f"{self.resource}/verify", payload, timeout=timeout)
+        if super().is_20x(response.status_code):
+            data = response.json().get("data")
+            account_payload = data.get("account")
+            account = DtoDecoder.decode(account_payload) if account_payload else None
+            return UnitResponse[AccountVerifyDTO](
+                AccountVerifyDTO(exists=bool(data.get("exists")), account=account), None
+            )
+        else:
+            return UnitError.from_json_api(response.json())
+

--- a/unit/models/account.py
+++ b/unit/models/account.py
@@ -382,3 +382,30 @@ class ListAccountParams(UnitParams):
         if self.to_balance:
             parameters["filter[toBalance]"] = self.to_balance
         return parameters
+
+
+class AccountVerifyRequest(UnitRequest):
+    def __init__(self, routing_number: str, account_number: str):
+        self.routing_number = routing_number
+        self.account_number = account_number
+
+    def to_json_api(self) -> Dict:
+        return {
+            "data": {
+                "type": "accountVerify",
+                "attributes": {
+                    "routingNumber": self.routing_number,
+                    "accountNumber": self.account_number,
+                },
+            }
+        }
+
+    def __repr__(self):
+        return json.dumps(self.to_json_api())
+
+
+class AccountVerifyDTO(object):
+    def __init__(self, exists: bool, account: Optional[AccountDTO] = None):
+        self.type = "accountVerify"
+        self.exists = exists
+        self.account = account


### PR DESCRIPTION
## Summary
- Add `AccountVerifyRequest` and `AccountVerifyDTO` to `unit/models/account.py`.
- Add `AccountResource.verify()` (`POST accounts/verify`) to `unit/api/account_resource.py`, returning whether an external routing/account pair is an on-us Unit `DepositAccount` (and, when present, the account + owning customer).
- Add an e2e test in `e2e_tests/test_account_verify.py`.

Backs Truss's migration to Unit's Verify Account API for detecting on-us accounts before Unit deprecates ACH->Book auto-conversion (2026-08-01).

## Consumers
- Truss-pmts/api#5101 pins this commit and calls `accounts/verify`. Merge this PR first, then repin api to the squashed `master` SHA.

## Test plan
- [ ] `python -m pytest e2e_tests/test_account_verify.py`