### PR TITLE
Fix SimulateIncomingAchPaymentDTO missing status arg

### DIFF
--- a/unit/models/payment.py
+++ b/unit/models/payment.py
@@ -43,9 +43,8 @@ class SimulateIncomingAchPaymentDTO(BasePayment):
                  description: str, amount: int, reason: Optional[str],
                  settlement_date: Optional[datetime], tags: Optional[Dict[str, str]],
                  relationships: Optional[Dict[str, Relationship]]):
-        BasePayment.__init__(self, id, created_at, direction, description, amount, reason, tags, relationships)
+        BasePayment.__init__(self, id, created_at, status, direction, description, amount, reason, tags, relationships)
         self.type = 'achPayment'
-        self.attributes["status"] = status
         self.settlement_date = settlement_date
 
     @staticmethod
@@ -53,6 +52,7 @@ class SimulateIncomingAchPaymentDTO(BasePayment):
         return BasePayment(
             _id,
             date_utils.to_datetime(attributes["createdAt"]),
+            attributes.get("status"),
             attributes.get("direction"),
             attributes["description"],
             attributes["amount"],


### PR DESCRIPTION
## Summary
- `SimulateIncomingAchPaymentDTO.from_json_api` omitted `status` when constructing `BasePayment`, so remaining positional args shifted (`direction` → `status`, `description` → `direction`, …) and a successful Unit sandbox simulate-incoming-ACH response raised `TypeError`.
- Mirror the working sibling `SimulateAchPaymentDTO.from_json_api`, which already passes `attributes.get("status")`.
- Also fix `__init__` to pass `status` into `BasePayment.__init__` (it previously skipped it and set `attributes["status"]` after the fact).

## Test plan
- [ ] Confirm `SimulateIncomingAchPaymentDTO.from_json_api` with a sandbox-shaped payload (including `status`) constructs without `TypeError`
- [ ] Confirm Truss `simulate_incoming_ach_payment` works against Unit sandbox without an api-repo monkeypatch of `from_json_api`


Made with [Cursor](https://cursor.com)